### PR TITLE
Chapter 11.

### DIFF
--- a/chapter_11/chapter11_2/chapter11_2.cpp
+++ b/chapter_11/chapter11_2/chapter11_2.cpp
@@ -1,0 +1,45 @@
+//
+// Brief: Listing 11.15 - randwalk.cpp
+// Topics: classes, friend functions, operator overloads
+//
+
+#include <iostream>
+#include <cstdlib>
+#include <ctime>
+#include "vector.cpp"
+
+int main () {
+  using namespace std;
+  using VECTOR::Vector;
+  srand(time(0));
+  double direction;
+  Vector step;
+  Vector result(0, 0);
+  unsigned long steps = 0;
+  double target;
+  double dstep;
+  cout << "Enter target distance (q to quit): ";
+  while (cin >> target) {
+    cout << "Enter step length: ";
+    if (!(cin >> dstep)) {
+      break;
+    }
+    while (result.magval() < target) {
+      direction = rand() % 360;
+      step.set(dstep, direction, 'p');
+      result = result + step;
+      steps++;
+    }
+    cout << "After " << steps << " steps, the subject "
+            "has the following location:" << endl;
+    cout << result << endl;
+    result.polar_mode();
+    cout << " or \n" << result << endl;
+    cout << "Average outward distance per step = " << result.magval()/steps << endl;
+    steps = 0;
+    result.set(0, 0);
+    cout << "Enter the target distance (q to quit): " << endl;
+  }
+
+  cout << "Bye!" << endl;
+}

--- a/chapter_11/chapter11_2/lib/README.md
+++ b/chapter_11/chapter11_2/lib/README.md
@@ -1,0 +1,1 @@
+_Stashing unmodified versions of vector.h and vector.cpp here for safe keeping since I'll be modifying the code for chapter11_3/_

--- a/chapter_11/chapter11_2/lib/vector.cpp
+++ b/chapter_11/chapter11_2/lib/vector.cpp
@@ -1,0 +1,108 @@
+#include "vector.h"
+#include <cmath>
+
+using std::sin;
+using std::cos;
+using std::atan2;
+using std::cout;
+
+namespace VECTOR {
+  const double RAD_TO_DEG = 57.2957795130823;
+
+  void Vector::set_mag () {
+    mag = sqrt((x * x) + (y * y));
+  }
+
+  void Vector::set_ang () {
+    if (x == 0.0 && y == 0.0) {
+      ang = 0.0;
+    } else {
+      ang = atan2(y, x);
+    }
+  }
+
+  void Vector::set_x () {
+    x = mag * cos(ang);
+  }
+  void Vector::set_y () {
+    y = mag * sin(ang);
+  }
+
+  Vector::Vector () {
+    x = y = mag = ang = 0.0;
+    mode = 'r';
+  }
+
+  Vector::Vector (double n1, double n2, char form) {
+    mode = form;
+    if (form == 'r') {
+      x = n1;
+      y = n2;
+      set_mag();
+      set_ang();
+
+    } else if (form == 'p') {
+      mag = n1;
+      ang = n2 / RAD_TO_DEG;
+      set_x();
+      set_y();
+    }
+  }
+
+  void Vector::set (double n1, double n2, char form) {
+    if (form == 'r') {
+      x = n1;
+      y = n2;
+      set_mag();
+      set_ang();
+
+    } else if (form == 'p') {
+      mag = n1;
+      ang = n2 / RAD_TO_DEG;
+      set_x();
+      set_y();
+    }
+  }
+
+  Vector::~Vector () {
+
+  }
+
+  void Vector::polar_mode () {
+    mode = 'p';
+  }
+
+  void Vector::rect_mode () {
+    mode = 'r';
+  }
+
+  Vector Vector::operator+ (const Vector & b) const {
+    return Vector(x + b.x, y + b.y);
+  }
+
+  Vector Vector::operator- (const Vector & b) const {
+    return Vector(x - b.x, y - b.y);
+  }
+
+  Vector Vector::operator- () const {
+    return Vector(-x, -y);
+  }
+
+  Vector Vector::operator* (double n) const {
+    return Vector(n*x, n*y);
+  }
+
+  Vector operator* (double n, const Vector & a) {
+    // utiilze the non-friend operator overload
+    return a * n;
+  }
+
+  std::ostream & operator<< (std::ostream & os, const Vector & v) {
+    if (v.mode == 'r') {
+      os << "(x,y) = (" << v.x << ", " << v.y << ")";
+    } else if (v.mode == 'p') {
+      os << "(m,a) = (" << v.mag << ", " << (v.ang * RAD_TO_DEG) << ")";
+    }
+    return os;
+  }
+} // end namespace VECTOR

--- a/chapter_11/chapter11_2/lib/vector.h
+++ b/chapter_11/chapter11_2/lib/vector.h
@@ -1,0 +1,36 @@
+#ifndef VECTOR_H_
+#define VECTOR_H_
+#include <iostream>
+
+namespace VECTOR {
+  class Vector {
+    private:
+      double x;
+      double y;
+      double mag;
+      double ang;
+      char mode;
+      void set_mag();
+      void set_ang();
+      void set_x();
+      void set_y();
+    public:
+      Vector ();
+      Vector (double n1, double n2, char form = 'r');
+      void set (double n1, double n2, char form = 'r');
+      ~Vector ();
+      double xval () const { return x; };
+      double yval () const { return y; };
+      double magval () const { return mag; };
+      double angval () const { return ang; };
+      void polar_mode ();
+      void rect_mode ();
+      Vector operator+ (const Vector & b) const;
+      Vector operator- (const Vector & b) const;
+      Vector operator- () const;
+      Vector operator* (double n) const;
+      friend Vector operator* (double n, const Vector & a);
+      friend std::ostream & operator<< (std::ostream & os, const Vector & v);
+  };
+} // end namespace VECTOR
+#endif

--- a/chapter_11/chapter11_2/vector.cpp
+++ b/chapter_11/chapter11_2/vector.cpp
@@ -1,0 +1,104 @@
+#include "vector.h"
+#include <cmath>
+
+using std::sin;
+using std::cos;
+using std::atan2;
+using std::cout;
+
+namespace VECTOR {
+  const double RAD_TO_DEG = 57.2957795130823;
+
+  double Vector::magval () const {
+    return sqrt((x * x) + (y * y));
+  }
+
+  double Vector::angval () const {
+    if (x == 0.0 && y == 0.0) {
+      return 0.0;
+    } else {
+      return atan2(y, x);
+    }
+  }
+
+  void Vector::set_x (double mag, double ang) {
+    x = mag * cos(ang);
+  }
+  void Vector::set_y (double mag, double ang) {
+    y = mag * sin(ang);
+  }
+
+  Vector::Vector () {
+    x = y = 0.0;
+    mode = 'r';
+  }
+
+  Vector::Vector (double n1, double n2, char form) {
+    mode = form;
+    if (form == 'r') {
+      x = n1;
+      y = n2;
+
+    } else if (form == 'p') {
+      double mag = n1;
+      double ang = n2 / RAD_TO_DEG;
+      set_x(mag, ang);
+      set_y(mag, ang);
+    }
+  }
+
+  void Vector::set (double n1, double n2, char form) {
+    if (form == 'r') {
+      x = n1;
+      y = n2;
+
+    } else if (form == 'p') {
+      double mag = n1;
+      double ang = n2 / RAD_TO_DEG;
+      set_x(mag, ang);
+      set_y(mag, ang);
+    }
+  }
+
+  Vector::~Vector () {
+
+  }
+
+  void Vector::polar_mode () {
+    mode = 'p';
+  }
+
+  void Vector::rect_mode () {
+    mode = 'r';
+  }
+
+  Vector Vector::operator+ (const Vector & b) const {
+    return Vector(x + b.x, y + b.y);
+  }
+
+  Vector Vector::operator- (const Vector & b) const {
+    return Vector(x - b.x, y - b.y);
+  }
+
+  Vector Vector::operator- () const {
+    return Vector(-x, -y);
+  }
+
+  Vector Vector::operator* (double n) const {
+    return Vector(n*x, n*y);
+  }
+
+  Vector operator* (double n, const Vector & a) {
+    // utiilze the non-friend operator overload
+    return a * n;
+  }
+
+  std::ostream & operator<< (std::ostream & os, const Vector & v) {
+    if (v.mode == 'r') {
+      os << "(x,y) = (" << v.x << ", " << v.y << ")";
+    } else if (v.mode == 'p') {
+      os << "(m,a) = (" << v.magval() << ", " << (v.angval() * RAD_TO_DEG) << ")";
+    }
+    return os;
+  }
+} // end namespace VECTOR

--- a/chapter_11/chapter11_2/vector.h
+++ b/chapter_11/chapter11_2/vector.h
@@ -1,0 +1,32 @@
+#ifndef VECTOR_H_
+#define VECTOR_H_
+#include <iostream>
+
+namespace VECTOR {
+  class Vector {
+    private:
+      double x;
+      double y;
+      char mode;
+      void set_x(double mag, double ang);
+      void set_y(double mag, double ang);
+    public:
+      Vector ();
+      Vector (double n1, double n2, char form = 'r');
+      void set (double n1, double n2, char form = 'r');
+      ~Vector ();
+      double xval () const { return x; };
+      double yval () const { return y; };
+      double magval () const;
+      double angval () const;
+      void polar_mode ();
+      void rect_mode ();
+      Vector operator+ (const Vector & b) const;
+      Vector operator- (const Vector & b) const;
+      Vector operator- () const;
+      Vector operator* (double n) const;
+      friend Vector operator* (double n, const Vector & a);
+      friend std::ostream & operator<< (std::ostream & os, const Vector & v);
+  };
+} // end namespace VECTOR
+#endif

--- a/chapter_11/chapter11_7/chapter11_7.cpp
+++ b/chapter_11/chapter11_7/chapter11_7.cpp
@@ -1,0 +1,28 @@
+//
+// Brief: Implementing Complex class.
+// Topics: operator overloads, >> overload, << overload
+//
+
+#include <iostream>
+#include "complex0.cpp"
+
+using namespace std;
+
+int main () {
+  Complex a(3, 4);
+  Complex c;
+  cout << "Enter a complex number (q to quit): \n";
+  while (cin >> c) {
+    cout << "c is " << c << endl;
+    cout << "complex conjugate is " << ~c << endl;
+    cout << "a is " << a << endl;
+    cout << "a + c is " << a + c << endl;
+    cout << "a - c is " << a - c << endl;
+    cout << "a * c is " << a * c << endl;
+    cout << "2 * c is " << 2 * c << endl;
+    cout << "Enter a complex number (q to quit): \n";
+  }
+
+  cout << "C ya!" << endl;
+
+}

--- a/chapter_11/chapter11_7/complex0.cpp
+++ b/chapter_11/chapter11_7/complex0.cpp
@@ -1,0 +1,51 @@
+#include "complex0.h"
+#include <iostream>
+
+Complex::Complex () {
+  real = imaginary = 0;
+}
+
+Complex::Complex (double real, double imaginary) {
+  this->real = real;
+  this->imaginary = imaginary;
+}
+
+Complex Complex::operator+ (const Complex & b) const {
+  return Complex(this->real + b.real, this->imaginary + b.imaginary);
+}
+
+Complex Complex::operator- (const Complex & b) const {
+  return Complex(this->real - b.real, this->imaginary - b.imaginary);
+}
+
+Complex Complex::operator* (const Complex & b) const {
+  return Complex((this->real * b.real) - (this->imaginary * b.imaginary),
+                (this->real * b.imaginary) + (this->imaginary * b.real));
+}
+
+Complex operator* (double real, const Complex & b) {
+  return Complex(real * b.real, real * b.imaginary);
+}
+
+Complex Complex::operator~ () const {
+  return Complex(this->real, -(this->imaginary));
+}
+
+std::ostream & operator<< (std::ostream & os, const Complex & b) {
+  os << "(" << b.real << ", " << b.imaginary << "i)";
+  return os;
+}
+
+std::istream & operator>> (std::istream & is, Complex & b) {
+  std::cout << "real: ";
+  is >> b.real;
+
+  if (is.fail()) {
+    return is;
+  }
+
+  std::cout << "imaginary: ";
+  is >> b.imaginary;
+
+  return is;
+}

--- a/chapter_11/chapter11_7/complex0.h
+++ b/chapter_11/chapter11_7/complex0.h
@@ -1,0 +1,21 @@
+#ifndef COMPLEX_H_
+#define COMPLEX_H_
+
+
+class Complex {
+  private:
+    double real;
+    double imaginary;
+  public:
+    Complex ();
+    Complex (double real, double imaginary);
+    Complex operator+ (const Complex & b) const;
+    Complex operator- (const Complex & b) const;
+    Complex operator* (const Complex & b) const;
+    Complex operator~ () const;
+    friend Complex operator* (double real, const Complex & b);
+    friend std::ostream & operator<< (std::ostream & os, const Complex & c);
+    friend std::istream & operator>> (std::istream & is, Complex & c);
+};
+
+#endif


### PR DESCRIPTION
I think it's a bit annoying to have to overload operators twice for full coverage. Eg

Obj + c is translated to `Obj.operator+(c)` but c + Obj is translated to `c.operator+(Obj)` forcing the developer to provide both a member function and a non-member function to handle both of the situations expressed above. I wish there was some language construct that would handle both cases, but usually it's a simple matter to loop both functions to the same set of logic via:

``` cpp
Obj operator+(int i, Obj & o) {
  // take advantage of our method overload operator
  // Obj.operator+(int i);
  return Obj + i;
}
```

